### PR TITLE
updated gradle kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Issue

<!-- Provide a reference to the issue that this change is going to address -->
Builds failing due to gradle script not referring to the correct Kotlin version for Android. 
<!-- E.g. #12 Issue title here -->

#[19] [The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.]

## Changes

<!-- Provide a detailed description of the changes proposed in this PR -->

1. Update Kotlin version in build.gradle
